### PR TITLE
fix: Arreglo de enlace caído

### DIFF
--- a/recursos-frameworks-javascript.md
+++ b/recursos-frameworks-javascript.md
@@ -1,6 +1,6 @@
 ## Angular
 
-* [Angular desde 0](https://frostqui.github.io/series/angular) (HTML)
+* [¿Qué es Angular? Aprende a instalarlo](https://codingpotions.com/introduccion-instalacion-angular) (HTML)
 * [Comunicar componentes en AngularJS 1.](https://carlosazaustre.es/formas-de-comunicar-componentes-en-angularjs-1-x/) (HTML)
 * [Desarrollo por componentes en AngularJS 1.](https://carlosazaustre.es/desarrollo-por-componentes-con-angular-1-5-con-es6-es2015/) (HTML)
 * [Framework](https://angularjs.org) (Web Oficial)


### PR DESCRIPTION
He cambiado el enlace de mi antiguo blog (frostqui.github.io) por el del nuevo blog que he creado (codingpotions.com).